### PR TITLE
SK webapp & charts support

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,16 +1,25 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <title>Plotteri</title>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="public/bundle.css"/>
+  <link rel="stylesheet" href="public/bundle.css" />
 </head>
+
 <body>
   <script type="text/javascript">
-    window.INITIAL_SETTINGS = {};
+    window.INITIAL_SETTINGS = {
+      data: [{
+        type: "signalk",
+        address: window.location.host
+      }],
+      signalKChartHost: window.location.protocol + "//" + window.location.host
+    };
   </script>
   <div id="app"></div>
   <script src="public/bundle.js"></script>
 </body>
+
 </html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Plotteri</title>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="public/bundle.css"/>
+</head>
+<body>
+  <script type="text/javascript">
+    window.INITIAL_SETTINGS = {};
+  </script>
+  <div id="app"></div>
+  <script src="public/bundle.js"></script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "mbtiles",
     "chart",
     "plotter",
-    "marine"
+    "marine",
+    "signalk-webapp"
   ],
   "dependencies": {
     "@mapbox/mbtiles": "0.9.0",

--- a/src/client/map.js
+++ b/src/client/map.js
@@ -39,6 +39,9 @@ function initMap(connection, settings, drawObject) {
   window.map = map
   addBasemap(map)
   addCharts(map, initialSettings.charts)
+  if (initialSettings.signalKChartHost) {
+    fetchSignalKCharts(map, initialSettings.signalKChartHost)
+  }
   const vesselIcons = createVesselIcons()
 
   const myVessel = Leaf.marker([0, 0], {icon: resolveIcon(vesselIcons, initialSettings.zoom), draggable: false, zIndexOffset: 990, rotationOrigin: 'center center', rotationAngle: 0})
@@ -247,6 +250,20 @@ function addCharts(map, charts) {
       map.panTo([center[1], center[0]])
     }
   }
+}
+
+function fetchSignalKCharts(map, address) {
+  fetch(address + "/signalk/v1/api/resources/charts")
+  .then(response => {
+    response.json().then(charts => {
+      _.values(charts).filter(chart => chart.tilemapUrl).forEach(chart => {
+        Leaf.tileLayer(chart.tilemapUrl).addTo(map)
+      })
+    })
+  })
+  .catch(err => {
+    console.error(err)
+  })
 }
 
 function addBasemap(map) {


### PR DESCRIPTION
This PR 
- makes tuktuk-chart-plotter a Signal K Node server webapp, installable with npm and available in the server's /apps list (add signalk-webapp keyword and static index.html)
- adds a configuration option to fetch the charts list from the SK server's `/resources/charts` endpoint
- if you start the app as a SK webapp via  the static `index.html` it will automatically connect to the SK server for data and fetch the charts list

Everything else should be working as previously.