### PR TITLE
Second suggestion for Tiny graphical edit on in instrument tab

### DIFF
--- a/src/styles/app.less
+++ b/src/styles/app.less
@@ -155,7 +155,6 @@ p {
   @media @tablet-and-desktop {
     transition: width 0.25s;
     .wrapper {
-      width: @rightBarWidth;
       overflow: hidden;
     }
     &.visible {


### PR DESCRIPTION
I took a closer look and the problem only append on a desktop browser when a scroll bar is used. 

When the scroll bar appear, the text don't shift to respect the original margin.
Removing this em 11 fix the problem and I didn't saw any negative impact.  
