### PR TITLE
Make leaflet respect minZoom, maxZoom and bounds of charts.

### DIFF
--- a/src/client/map.js
+++ b/src/client/map.js
@@ -226,9 +226,9 @@ function addCharts(map, providers, providersP) {
     map.createPane(pane)
     const bounds = parseChartBounds(provider)
     // 'detectRetina' messes up Leaflet maxNativeZoom, fix with a hack:
-    const maxNativeZoom = maxzoom ? maxzoom - (Leaf.Browser.retina ? 1 : 0) : undefined
-    const minNativeZoom = minzoom ? minzoom + (Leaf.Browser.retina ? 1 : 0) : undefined
-    const layer = Leaf.tileLayer(tilemapUrl, {detectRetina: true, bounds, maxNativeZoom, minNativeZoom, pane})
+    const maxNativeZoom = maxzoom ? (maxzoom - (Leaf.Browser.retina ? 1 : 0)) : undefined
+    const minNativeZoom = minzoom ? (minzoom + (Leaf.Browser.retina ? 1 : 0)) : undefined
+    const layer = Leaf.tileLayer(tilemapUrl, {detectRetina: true, bounds: bounds, maxZoom: maxNativeZoom, minZoom: minNativeZoom, pane: pane, className: name})
 
     if (enabled) {
       layer.addTo(map)

--- a/src/client/map.js
+++ b/src/client/map.js
@@ -226,9 +226,16 @@ function addCharts(map, providers, providersP) {
     map.createPane(pane)
     const bounds = parseChartBounds(provider)
     // 'detectRetina' messes up Leaflet maxNativeZoom, fix with a hack:
-    const maxNativeZoom = maxzoom ? (maxzoom - (Leaf.Browser.retina ? 1 : 0)) : undefined
-    const minNativeZoom = minzoom ? (minzoom + (Leaf.Browser.retina ? 1 : 0)) : undefined
-    const layer = Leaf.tileLayer(tilemapUrl, {detectRetina: true, bounds: bounds, maxZoom: maxNativeZoom, minZoom: minNativeZoom, pane: pane, className: name})
+    const maxNativeZoom = maxzoom ? (maxzoom - Leaf.Browser.retina ? 1 : 0) : undefined
+    const minNativeZoom = minzoom ? (minzoom + Leaf.Browser.retina ? 1 : 0) : undefined
+    const layer = Leaf.tileLayer(tilemapUrl, {
+      detectRetina: true,
+      bounds: bounds,
+      maxZoom: maxNativeZoom,
+      minZoom: minNativeZoom,
+      pane: pane,
+      className: name
+    })
 
     if (enabled) {
       layer.addTo(map)


### PR DESCRIPTION
This is a HUGE performance increase, leaflet was trying to load every tiles of the most precise map all around the world regardless of the current zoom and charts boundaries.