### PR TITLE
feature: send cookies in fetch requests

### DIFF
--- a/src/client/api.js
+++ b/src/client/api.js
@@ -16,7 +16,7 @@ function parseJSON(response) {
 }
 
 function get({url}) {
-  const request = fetch(url)
+  const request = fetch(url, {credentials: 'include'})
     .then(checkStatus)
     .then(parseJSON)
   return Bacon.fromPromise(request)


### PR DESCRIPTION
Signal K server with security turned on and readonly
access false requires cookies for the requests to
work. Fixes #19